### PR TITLE
feat: domain entities

### DIFF
--- a/src/ClubeAcesso/Domain/Entities/AreaClube.cs
+++ b/src/ClubeAcesso/Domain/Entities/AreaClube.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Domain.Entities
+{
+    public class AreaClube
+    {
+        public Guid Id { get; set; }
+        public string Nome { get; set; } = null!;
+    }
+}

--- a/src/ClubeAcesso/Domain/Entities/PlanoAcesso.cs
+++ b/src/ClubeAcesso/Domain/Entities/PlanoAcesso.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Domain.Entities
+{
+    public class PlanoAcesso
+    {
+        public Guid Id { get; set; }
+        public string Nome { get; set; } = null!;
+        public ICollection<AreaClube> Areas { get; set; } = null!;
+    }
+}

--- a/src/ClubeAcesso/Domain/Entities/Socio.cs
+++ b/src/ClubeAcesso/Domain/Entities/Socio.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Domain.Entities
+{
+    public class Socio
+    {
+        public Guid Id { get; set; }
+        public string Nome { get; set; } = null!;
+        public string Documento { get; set; } = null!;
+        public Guid PlanoId { get; set; }
+        public PlanoAcesso Plano { get; set; } = null!;
+    }
+}

--- a/src/ClubeAcesso/Domain/Entities/TentativaAcesso.cs
+++ b/src/ClubeAcesso/Domain/Entities/TentativaAcesso.cs
@@ -1,0 +1,18 @@
+﻿using Domain.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Domain.Entities
+{
+    public class TentativaAcesso
+    {
+        public Guid Id { get; set; }
+        public Guid SocioId { get; set; }
+        public Guid AreaId { get; set; }
+        public DateTime DataHora { get; set; }
+        public ResultadoTentativa Resultado { get; set; }
+    }
+}

--- a/src/ClubeAcesso/Domain/Enums/ResultadoTentativa.cs
+++ b/src/ClubeAcesso/Domain/Enums/ResultadoTentativa.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Domain.Enums
+{
+    public enum ResultadoTentativa
+    {
+        Autorizado,
+        Negado
+    }
+}


### PR DESCRIPTION
Este PR adiciona as entidades principais do domínio do sistema de controle de acesso ao clube:

- `Socio`
- `PlanoAcesso`
- `AreaClube`
- `TentativaAcesso`
- Enum `ResultadoTentativa`

As entidades foram organizadas em `/Domain/Entities` e definem as relações básicas e estrutura do núcleo de negócio, sem dependência de EF Core.

Essas entidades serão usadas nas próximas etapas para mapear a base de dados e construir as regras de negócio.